### PR TITLE
Add day name matching to example

### DIFF
--- a/examples/example-2.el
+++ b/examples/example-2.el
@@ -19,6 +19,7 @@
 (defconst date-re "[0-9]\\{4\\}-[0-9]\\{2\\}-[0-9]\\{2\\}")
 (defconst time-re "[0-9]\\{2\\}:[0-9]\\{2\\}")
 (defconst day-re "[A-Za-z]\\{3\\}")
+(defconst day-time-re (format "\\(%s\\)? ?\\(%s\\)?" day-re time-re))
 
 (defun svg-progress-percent (value)
   (svg-image (svg-lib-concat
@@ -71,25 +72,25 @@
                                                               :crop-left t))))
 
         
-        ;; Active date (without day name, with or without time)
+        ;; Active date (with or without day name, with or without time)
         (,(format "\\(<%s>\\)" date-re) .
          ((lambda (tag)
             (svg-tag-make tag :beg 1 :end -1 :margin 0))))
-        (,(format "\\(<%s *\\)%s>" date-re time-re) .
+        (,(format "\\(<%s \\)%s>" date-re day-time-re) .
          ((lambda (tag)
             (svg-tag-make tag :beg 1 :inverse nil :crop-right t :margin 0))))
-        (,(format "<%s *\\(%s>\\)" date-re time-re) .
+        (,(format "<%s \\(%s>\\)" date-re day-time-re) .
          ((lambda (tag)
             (svg-tag-make tag :end -1 :inverse t :crop-left t :margin 0))))
 
-        ;; Inactive date  (without day name, with or without time)
+        ;; Inactive date  (with or without day name, with or without time)
          (,(format "\\(\\[%s\\]\\)" date-re) .
           ((lambda (tag)
              (svg-tag-make tag :beg 1 :end -1 :margin 0 :face 'org-date))))
-         (,(format "\\(\\[%s *\\)%s\\]" date-re time-re) .
+         (,(format "\\(\\[%s \\)%s\\]" date-re day-time-re) .
           ((lambda (tag)
              (svg-tag-make tag :beg 1 :inverse nil :crop-right t :margin 0 :face 'org-date))))
-         (,(format "\\[%s *\\(%s\\]\\)" date-re time-re) .
+         (,(format "\\[%s \\(%s\\]\\)" date-re day-time-re) .
           ((lambda (tag)
              (svg-tag-make tag :end -1 :inverse t :crop-left t :margin 0 :face 'org-date))))))
 
@@ -101,7 +102,11 @@
 ;; Progress:      [1/3]
 ;;                [42%]
 ;; Active date:   <2021-12-24>
+;;                <2021-12-24 Fri>
 ;;                <2021-12-24 14:00>
+;;                <2021-12-24 Fri 14:00>
 ;; Inactive date: [2021-12-24]
+;;                [2021-12-24 Fri]
 ;;                [2021-12-24 14:00]
+;;                [2021-12-24 Fri 14:00]
 ;; Citation:      [cite:@Knuth:1984] 


### PR DESCRIPTION
I futzed for a couple of hours and finally figured out how to get day names also matched. I like having the day names and that is added by default (I think) anyways for when you mark something done.

It looks really nice! Please add this so others will not have to struggle like me :)

![image](https://user-images.githubusercontent.com/12320165/152896355-c53f886f-bdcd-4dac-bc5c-12030eaaa386.png)
 