### PR TITLE
Allow :face property of svg-tag-make to be a property list

### DIFF
--- a/svg-tag-mode.el
+++ b/svg-tag-mode.el
@@ -156,6 +156,15 @@ string as argument and returns a SVG tag."
   :group 'svg-tag)
 
 
+(defun svg-tag--face-attribute (face attribute)
+  "Return the value of FACE's ATTRIBUTE in the selected frame.
+FACE can either be a face or a property list."
+  (if (facep face)
+      (face-attribute face attribute nil 'default)
+    (or (plist-get face attribute)
+        (face-attribute 'svg-tag-default-face attribute nil 'default))))
+
+
 (defun svg-tag-make (tag &optional &rest args)
   "Return a svg tag displaying TAG and using specified ARGS.
    
@@ -168,8 +177,8 @@ string as argument and returns a SVG tag."
   :end (integer) specifies the last index of the tag substring to
                  take into account (default nil)
 
-  :face (face) indicates the face to use to compute foreground &
-               background color (default 'default)
+  :face (face) indicates the face or property list to use to compute 
+               foreground & background color. (default 'default)
 
   :inverse (bool) indicates whether to inverse foreground &
                   background color (default nil)
@@ -180,6 +189,8 @@ string as argument and returns a SVG tag."
    to call svg-lib-tag directly."
   
   (let* ((face (or (plist-get args :face) 'svg-tag-default-face))
+         (foreground (svg-tag--face-attribute face :foreground))
+         (background (svg-tag--face-attribute face :background))
          (inverse (or (plist-get args :inverse) nil))
          (tag (string-trim tag))
          (beg (or (plist-get args :beg) 0))
@@ -192,15 +203,15 @@ string as argument and returns a SVG tag."
         (apply #'svg-lib-tag (substring tag beg end) nil
                :stroke 0
                :font-weight 'semibold
-               :foreground (face-background face nil 'default)
-               :background (face-foreground face nil 'default)
+               :foreground background
+               :background foreground
                args)
       (apply #'svg-lib-tag (substring tag beg end) nil
-                   :stroke 2
-                   :font-weight 'regular
-                   :foreground (face-foreground face nil 'default)
-                   :background (face-background face nil 'default)
-                   args))))
+             :stroke 2
+             :font-weight 'regular
+             :foreground foreground
+             :background background
+             args))))
 
 (defun svg-tag--cursor-function (_win position direction)
   "This function processes action at point. Action can be:


### PR DESCRIPTION
This modification allows the `:face` property of `svg-tag-make` be either a face or a property list of face attributes. This enables one to make SVG tags for custom Org TODO keywords that don't have their own dedicated face. This shouldn't break anything because it doesn't change the existing functionality.

I have attached below my modified example-2.el (which is not part of the pull request) to illustrate how it works. To see how it looks for my custom Org TODO keywords, use the following setting:

```
  (setq org-todo-keyword-faces
        '(("TODO" . (:foreground "Red1" :weight bold))
          ("TASK" . (:foreground "MediumBlue" :weight bold))
          ("BEGAN" . (:foreground "DarkViolet" :weight bold))
          ("WAIT" . (:foreground "DarkOrange1" :weight bold))
          ("HOLD" . (:foreground "SlateGray" :weight bold))
          ("VOID" . (:foreground "Brown" :weight bold))
          ("DONE" . (:foreground "PaleGreen4" :weight bold))))
```

[example-2.el.txt](https://github.com/rougier/svg-tag-mode/files/10351435/example-2.el.txt)

The only caveat is that `org-todo-keyword-faces` allows the keyword faces to not only property lists, but also symbols (that map to a face), and color strings (that inherit other attributes from the `org-todo' face. I haven't implemented those cases, but I can for completeness if you are interested.

Both this and svg-lib are great packages! You have made a lot of great contributions for improving the aesthetics of Emacs. Thanks so much!