### PR TITLE
Allow :face property of svg-tag-make to be a string

### DIFF
--- a/svg-tag-mode.el
+++ b/svg-tag-mode.el
@@ -158,11 +158,16 @@ string as argument and returns a SVG tag."
 
 (defun svg-tag--face-attribute (face attribute)
   "Return the value of FACE's ATTRIBUTE in the selected frame.
-FACE can either be a face or a property list."
+FACE can either be a face, property list (i.e., an anonymous
+face), or a string (assumed to be the foreground attribute). If
+ATTRIBUTE is not specified in FACE, then use the corresponding
+attribute from ``svg-tag-default-face''."
   (if (facep face)
       (face-attribute face attribute nil 'default)
-    (or (plist-get face attribute)
-        (face-attribute 'svg-tag-default-face attribute nil 'default))))
+    (if (and (stringp face) (eq attribute :foreground))
+        face
+      (or (plist-get face attribute)
+          (face-attribute 'svg-tag-default-face attribute nil 'default)))))
 
 
 (defun svg-tag-make (tag &optional &rest args)
@@ -177,8 +182,8 @@ FACE can either be a face or a property list."
   :end (integer) specifies the last index of the tag substring to
                  take into account (default nil)
 
-  :face (face) indicates the face or property list to use to compute 
-               foreground & background color. (default 'default)
+  :face (face) indicates the face, property list or string to use to 
+               compute foreground & background color. (default 'default)
 
   :inverse (bool) indicates whether to inverse foreground &
                   background color (default nil)


### PR DESCRIPTION
This modification allows, for completeness, for the `:face` property of `svg-tag-make` to be a string. That string is assumed to be the value of the `:foreground` attribute. This modification allows one to use all the possible values of faces specified in `org-todo-keyword-faces`.