### PR TITLE
Fix quotes in docstrings

### DIFF
--- a/svg-tag-mode.el
+++ b/svg-tag-mode.el
@@ -183,7 +183,7 @@ attribute from ``svg-tag-default-face''."
                  take into account (default nil)
 
   :face (face) indicates the face, property list or string to use to 
-               compute foreground & background color. (default 'default)
+               compute foreground & background color. (default `default')
 
   :inverse (bool) indicates whether to inverse foreground &
                   background color (default nil)
@@ -267,7 +267,7 @@ attribute from ``svg-tag-default-face''."
     `(,pattern 1 ,tag)))
 
 (defun svg-tag--remove-text-properties (oldfun start end props &rest args)
-  "This applies remove-text-properties with 'display removed from props"
+  "This applies remove-text-properties with `display' removed from props"
   (apply oldfun start end (svg-tag--plist-delete props 'display) args))
 
 (defun svg-tag--org-fontify-meta-lines-and-blocks (oldfun &rest args)


### PR DESCRIPTION
In docstrings, symbols should not be quoted as they are quoted in code.  That's not being done in Emacs itself at least.

If you really want to 'quote, then you have to write:

```
\\='quote
```